### PR TITLE
updated error handling

### DIFF
--- a/Bouncr/Models/GenericResponse.swift
+++ b/Bouncr/Models/GenericResponse.swift
@@ -9,4 +9,13 @@ import Foundation
 struct GenericResponse: Codable {
     let returnValue:Int
     let returnString:String?
+    func getErrorEnum() -> RequestError? {
+        if returnValue>0{
+            return nil
+        }
+        switch returnValue{
+        case -2: return .invalidLogin
+        default:return .serverSideError
+        }
+    }
 }

--- a/Bouncr/Network/Base/HTTPClient.swift
+++ b/Bouncr/Network/Base/HTTPClient.swift
@@ -41,7 +41,10 @@ extension HTTPClient {
                     guard let decodedGenericResponse = try? decoder.decode(GenericResponse.self, from: data)else {
                         return .failure(.decode)
                     }
-                    return .failure(.serverSideError)
+                    guard let decodedError =  decodedGenericResponse.getErrorEnum()  else {
+                        return.failure(.serverSideError)
+                    }
+                    return .failure(decodedError)
                 }
                 return .success(decodedResponse)
             

--- a/Bouncr/Network/Base/RequestError.swift
+++ b/Bouncr/Network/Base/RequestError.swift
@@ -15,6 +15,7 @@ enum RequestError: Error {
     case unexpectedStatusCode
     case unknown
     case serverSideError
+    case invalidLogin
     
     var customMessage: String {
         switch self {
@@ -24,8 +25,12 @@ enum RequestError: Error {
             return "Session expired"
         case .serverSideError:
             return "Operation not allowed by service"
+        case .invalidLogin:
+            return "Invalid login"
         default:
             return "Unknown error"
         }
     }
 }
+
+

--- a/BouncrTests/Intergration Tests/UserIntergrationTest.swift
+++ b/BouncrTests/Intergration Tests/UserIntergrationTest.swift
@@ -49,6 +49,20 @@ class UserIntergrationTest: XCTestCase {
         waitForExpectations(timeout: 3.0, handler: nil)
     }
     
+    func testLoginServerFail() throws {
+        let controller = MainController()
+        
+        let expectation = expectation(description: "login to service")
+        
+        controller.login(username: "khu", password: "secret12345") {
+            
+            XCTAssertEqual(controller.token, "")
+            XCTAssertEqual(controller.errorMessage, "Invalid login")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 3.0, handler: nil)
+    }
+    
     
     
     func testCreateServer() throws {

--- a/BouncrTests/Mocks/JSON/BadGenericResponse2.json
+++ b/BouncrTests/Mocks/JSON/BadGenericResponse2.json
@@ -1,0 +1,4 @@
+{
+    "returnValue":-2,
+    "returnString":"fail"
+}

--- a/BouncrTests/Mocks/UserServiceMock.swift
+++ b/BouncrTests/Mocks/UserServiceMock.swift
@@ -20,6 +20,9 @@ final class UserServiceMock: Mockable, UserServiceable {
     
     
     func userLogin(username: String, password: String) async -> Result<User, RequestError> {
+        if(password == "wrongPassword"){
+            return .failure(.invalidLogin)
+        }
         return .success(loadJSON(filename: "ReturnUser", type: User.self))
     }
     

--- a/BouncrTests/Unit Tests/UserTest.swift
+++ b/BouncrTests/Unit Tests/UserTest.swift
@@ -48,6 +48,21 @@ class UserTest: XCTestCase {
         }
     }
     
+    
+    
+    func testUserServiceMockBadLogin() async {
+        let mock = UserServiceMock()
+        let res = try await mock.userLogin(username: "", password: "wrongPassword")
+        
+        switch res {
+        case .success(_):
+            XCTFail("The request should not fail")
+            
+        case .failure:
+            XCTAssertEqual(true,true)
+        }
+    }
+    
     func testUserServiceMockCreate() async {
         let mock = UserServiceMock()
         let testUser = User(id: 1, firstName: "test", lastName: "test", email: "test", username: "test", phoneNumber: 1, birthday: Date(), orgUser: nil, password: nil,token:  nil)
@@ -63,7 +78,20 @@ class UserTest: XCTestCase {
     }
     
     // controller tests
-    func testLogin() throws {
+    func testLoginBad() throws {
+        let controller = MainController(service: UserServiceMock())
+        
+        let expectation = expectation(description: "login to service")
+        
+        controller.login(username: "khu", password: "wrongPassword") {
+            expectation.fulfill()
+            XCTAssertEqual(controller.token, "")
+            XCTAssertEqual(controller.errorMessage!,"Invalid login")
+        }
+        waitForExpectations(timeout: 3.0, handler: nil)
+    }
+    
+    func testLoginGood() throws {
         let controller = MainController(service: UserServiceMock())
         
         let expectation = expectation(description: "login to service")


### PR DESCRIPTION
for every response, the http client will attempt to parse it into the intended datatype (e.g. users, event), if that fails, it will try and parse it as a generic response. it will then check to see if the `returnValue`  is negative, indicating an error. A failure will be passed to the controller and the status code will be updated.  Feel free to define more errors by 


1. update the responseError enum by adding in a new case and defining its status message if required
2. make the rails service return a generic response with a new returnValue, the number is the position of the newly defined responseError enum (if the new error is the ith error defined in the enum file, the new return value is i)