### PR TITLE
added attendence and checked in count for event

### DIFF
--- a/Bouncr/Models/Event.swift
+++ b/Bouncr/Models/Event.swift
@@ -33,7 +33,8 @@ struct Event: Codable,JSONCreatable {
     let venueLatitude: Double
     let venueLongitude: Double
     let organizations: [Organization]?
-    
+    let acceptedInvitesCount: Int?
+    let checkedInInvitescount: Int?
     
     func toDict() -> [String:String]? {
         var newEvent:[String:String] = [

--- a/BouncrTests/Intergration Tests/EventIntergrationTest.swift
+++ b/BouncrTests/Intergration Tests/EventIntergrationTest.swift
@@ -40,6 +40,8 @@ class EventIntergrationTest: XCTestCase {
         
         controller.hostedEventController.getHostedEvents(){
            XCTAssertEqual(controller.hostedEventController.eventArray.first?.name ,"Art Night")
+            XCTAssertEqual(controller.hostedEventController.eventArray.first?.acceptedInvitesCount ,2)
+            XCTAssertEqual(controller.hostedEventController.eventArray.first?.checkedInInvitescount ,1)
             XCTAssertEqual(controller.hostedEventController.eventArray.last?.name ,"Charity Dinner")
             expectation.fulfill()
         }
@@ -51,7 +53,7 @@ class EventIntergrationTest: XCTestCase {
         let controller = MainController()
         controller.manualLoginForTesting()
         let expectation = expectation(description: "create hosted events")
-        let newEvent = Event(id: -1, name: "newEvent", startTime: Date(), endTime: Date(), street1: "here", street2: "there", city: "happytown", state: "PA", zip: 15213, description: "have fun", attendenceVisible: true, friendsAttendingVisible: true, attendenceCap: 3, coverCharge: 2.2, isOpenInvite: true, venueLatitude: 0.0, venueLongitude: 0.0, organizations: nil)
+        let newEvent = Event(id: -1, name: "newEvent", startTime: Date(), endTime: Date(), street1: "here", street2: "there", city: "happytown", state: "PA", zip: 15213, description: "have fun", attendenceVisible: true, friendsAttendingVisible: true, attendenceCap: 3, coverCharge: 2.2, isOpenInvite: true, venueLatitude: 0.0, venueLongitude: 0.0, organizations: nil, acceptedInvitesCount: nil, checkedInInvitescount: nil)
         
         controller.hostedEventController.createEvent(newEvent: newEvent){
            XCTAssertEqual(controller.hostedEventController.eventShowed?.name ,"newEvent")
@@ -64,7 +66,7 @@ class EventIntergrationTest: XCTestCase {
         let controller = MainController()
         controller.manualLoginForTesting()
         let expectation = expectation(description: "updated hosted events")
-        let newEvent = Event(id: 1, name: "newUpdatedEvent", startTime: Date(), endTime: Date(), street1: "here", street2: "there", city: "happytown", state: "PA", zip: 15213, description: "have fun", attendenceVisible: true, friendsAttendingVisible: true, attendenceCap: 3, coverCharge: 2.2, isOpenInvite: true, venueLatitude: 0.0, venueLongitude: 0.0, organizations: nil)
+        let newEvent = Event(id: 1, name: "newUpdatedEvent", startTime: Date(), endTime: Date(), street1: "here", street2: "there", city: "happytown", state: "PA", zip: 15213, description: "have fun", attendenceVisible: true, friendsAttendingVisible: true, attendenceCap: 3, coverCharge: 2.2, isOpenInvite: true, venueLatitude: 0.0, venueLongitude: 0.0, organizations: nil, acceptedInvitesCount: nil, checkedInInvitescount: nil)
         
         controller.hostedEventController.updateEvent(updatedEvent: newEvent){
            XCTAssertEqual(controller.hostedEventController.eventShowed?.name ,"newUpdatedEvent")

--- a/BouncrTests/Unit Tests/EventTest.swift
+++ b/BouncrTests/Unit Tests/EventTest.swift
@@ -82,7 +82,7 @@ class EventTest: XCTestCase {
         
         let expectation = expectation(description: "get all friends")
         
-        let newEvent = Event(id: 1, name: "", startTime: Date(), endTime: Date(), street1: "", street2: nil, city: "", state: "", zip: 1, description: nil, attendenceVisible: true, friendsAttendingVisible: true, attendenceCap: 1, coverCharge: 0.0, isOpenInvite: true, venueLatitude: 0.0, venueLongitude: 0.0, organizations: nil)
+        let newEvent = Event(id: 1, name: "", startTime: Date(), endTime: Date(), street1: "", street2: nil, city: "", state: "", zip: 1, description: nil, attendenceVisible: true, friendsAttendingVisible: false, attendenceCap: 32, coverCharge: 42.2, isOpenInvite: false, venueLatitude: 1.1, venueLongitude: 2.2, organizations: nil, acceptedInvitesCount: nil, checkedInInvitescount: nil)
         controller.createEvent(newEvent: newEvent){
             expectation.fulfill()
             XCTAssertEqual(controller.eventShowed?.name,"Art Night")
@@ -96,7 +96,9 @@ class EventTest: XCTestCase {
         
         let expectation = expectation(description: "get all friends")
         
-        let newEvent = Event(id: 1, name: "", startTime: Date(), endTime: Date(), street1: "", street2: nil, city: "", state: "", zip: 1, description: nil, attendenceVisible: true, friendsAttendingVisible: true, attendenceCap: 1, coverCharge: 0.0, isOpenInvite: true, venueLatitude: 0.0, venueLongitude: 0.0, organizations: nil)
+        let newEvent = Event(id: 1, name: "", startTime: Date(), endTime: Date(), street1: "", street2: nil, city: "", state: "", zip: 1, description: nil, attendenceVisible: true, friendsAttendingVisible: false, attendenceCap: 32, coverCharge: 42.2, isOpenInvite: false, venueLatitude: 1.1, venueLongitude: 2.2, organizations: nil, acceptedInvitesCount: nil, checkedInInvitescount: nil)
+        
+        
         controller.updateEvent(updatedEvent: newEvent){
             expectation.fulfill()
             XCTAssertEqual(controller.eventShowed?.name,"Art Night")


### PR DESCRIPTION
I added 2 new fields that will display the number of total accepted invites and total checked in invites for an event. Right now these fields are only populated when the host_event call is made. lmk if this needs to be populated in other cases
